### PR TITLE
[Tech Debt] lsoria/Refactorizar checkeo de led_port

### DIFF
--- a/src/leds.c
+++ b/src/leds.c
@@ -49,12 +49,12 @@ static uint16_t * led_port;
 
 int leds_init(uint16_t * port) {
     led_port = port;
-    *led_port = 0x00;
+    leds_turn_off_all();
     return 0;
 }
 
 void leds_deinit(void) {
-    *led_port = 0x00;
+    leds_turn_off_all();
     led_port = NULL;
 }
 

--- a/src/leds.c
+++ b/src/leds.c
@@ -31,6 +31,10 @@ SPDX-License-Identifier: MIT
 /* === Macros definitions ====================================================================== */
 
 #define LED_TO_BIT(led) (1 << led - 1)
+#define CHECK_LED_PORT(port)                                                                       \
+    if (!led_port) {                                                                               \
+        return -1;                                                                                 \
+    }
 
 /* === Private data type declarations ========================================================== */
 /* === Private variable declarations =========================================================== */
@@ -55,55 +59,43 @@ void leds_deinit(void) {
 }
 
 int leds_turn_on_single(uint16_t led) {
-    if (led_port) {
-        *led_port |= LED_TO_BIT(led);
-        return 0;
-    } else {
-        return -1;
-    }
+    CHECK_LED_PORT(led_port);
+
+    *led_port |= LED_TO_BIT(led);
+    return 0;
 }
 
 int leds_turn_off_single(uint16_t led) {
-    if (led_port) {
-        *led_port &= ~LED_TO_BIT(led);
-        return 0;
-    } else {
-        return -1;
-    }
+    CHECK_LED_PORT(led_port);
+
+    *led_port &= ~LED_TO_BIT(led);
+    return 0;
 }
 
 int leds_get_status_single(uint16_t led) {
-    if (led_port) {
-        return (*led_port & LED_TO_BIT(led)) != 0;
-    } else {
-        return -1;
-    }
+    CHECK_LED_PORT(led_port);
+
+    return (*led_port & LED_TO_BIT(led)) != 0;
 }
 
 int leds_turn_on_all(void) {
-    if (led_port) {
-        *led_port = 0xFF;
-        return 0;
-    } else {
-        return -1;
-    }
+    CHECK_LED_PORT(led_port);
+
+    *led_port = 0xFF;
+    return 0;
 }
 
 int leds_turn_off_all(void) {
-    if (led_port) {
-        *led_port = 0x00;
-        return 0;
-    } else {
-        return -1;
-    }
+    CHECK_LED_PORT(led_port);
+
+    *led_port = 0x00;
+    return 0;
 }
 
 int leds_get_status_all(void) {
-    if (led_port) {
-        return *led_port;
-    } else {
-        return -1;
-    }
+    CHECK_LED_PORT(led_port);
+
+    return *led_port;
 }
 
 /* === End of documentation ==================================================================== */


### PR DESCRIPTION
# Descripción
Aplicadas correcciones en base a las observaciones marcadas en #2 , las cuales son dos:

1. Evitar bloques repetidos que chequean que `led_port` no sea `NULL`. Para ello se creó la siguiente macro:
```
#define CHECK_LED_PORT(port) 
    if (!led_port) {
        return -1; 
    }
```
De esta forma, se puede chequear la nulidad de `led_port` al comienzo de cada función de la API.

2. Cada vez que se ejecute `*leds_port = 0x00;`, llamar directamente a `leds_turn_off_all()` para mantener claridad.

## Testing hecho
Todas las pruebas unitarias han pasado, así como los chequeos de `pre-commit`